### PR TITLE
it should be d value instead of the Asc value

### DIFF
--- a/src/utilities/astronomy.js
+++ b/src/utilities/astronomy.js
@@ -109,7 +109,7 @@ export const getAscendant = ({latitude=0.00, obliquityEcliptic=23.4367, localSid
   // https://en.wikipedia.org/wiki/Ascendant
   // citation Peter Duffett-Smith, Jonathan Zwart, Practical astronomy with your calculator or spreadsheet-4th ed., p47, 2011
 
-  if (ascendant < 0) {
+  if (d < 0) {
     ascendant += 180
   } else {
     ascendant += 360


### PR DESCRIPTION
#1 - The first condition fix.

The x (d) value in the formula should be used instead of the ascendant value found in the first condition.

The Ascendant is then found in the correct quadrant (0 to 360 degrees) by using the two rules
https://wikimedia.org/api/rest_v1/media/math/render/svg/68649ded47b9e668ef643fbf313d157ed4037022