### PR TITLE
Fixed issue with ascendant calculation utility.

### DIFF
--- a/src/utilities/astronomy.js
+++ b/src/utilities/astronomy.js
@@ -117,6 +117,8 @@ export const getAscendant = ({latitude=0.00, obliquityEcliptic=23.4367, localSid
 
   if (ascendant >= 180) {
     ascendant -= 180
+  } else {
+    ascendant += 180
   }
 
   return modulo(ascendant, 360)


### PR DESCRIPTION
According to https://en.wikipedia.org/wiki/Ascendant, 180 degrees must be added to the ascendant degree if the calculated ascendant degree is less than 180 degrees.

Tested with the following parameters and validated with Astro.com.

Lat: 40.65871
Lng: -73.64124
Date: March 25th, 1989

Correct Ascendant Zodiac: Aquarius

<img width="924" alt="Screen Shot 2021-01-14 at 7 35 53 PM" src="https://user-images.githubusercontent.com/20268348/104665562-bcaa5380-569f-11eb-8f7b-93ee76017803.png">
